### PR TITLE
Update copyright years to 2025 and fix email

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 **The MIT License (MIT)**
 
-Copyright &copy; 2020, Emma Powers
+Copyright &copy; 2020-2025, Emma Powers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bakelite/generator/runtimes/common/crc.h
+++ b/bakelite/generator/runtimes/common/crc.h
@@ -1,6 +1,6 @@
 /*
  * Bakelite CRC Functions (C99)
- * Copyright (c) Emma Powers 2021-2024
+ * Copyright (c) Emma Powers 2021-2025
  *
  * Platform-independent CRC-8, CRC-16, and CRC-32 implementations
  * with flash storage support for embedded platforms.

--- a/bakelite/generator/templates/cpptiny-bakelite.h.j2
+++ b/bakelite/generator/templates/cpptiny-bakelite.h.j2
@@ -1,5 +1,5 @@
 /*
- * The code in this file is Copyright (c) Emma Powers 2021,
+ * The code in this file is Copyright (c) Emma Powers 2021-2025,
  * unless otherwise marked. This software is made available
  * under the terms of the MIT License, which can be found at the
  * bottom of this file.

--- a/bakelite/generator/templates/ctiny-bakelite.h.j2
+++ b/bakelite/generator/templates/ctiny-bakelite.h.j2
@@ -1,6 +1,6 @@
 /*
  * Bakelite C Runtime
- * Copyright (c) Emma Powers 2021-2024
+ * Copyright (c) Emma Powers 2021-2025
  *
  * C99 compatible header-only implementation for embedded systems.
  * Licensed under the MIT License (see end of file).

--- a/bin/update
+++ b/bin/update
@@ -12,7 +12,7 @@ CWD = os.getcwd()
 TMP = tempfile.gettempdir()
 CONFIG = {
     "full_name": "Emma Powers",
-    "email": "emmapowers@gmail.com",
+    "email": "emma@emmaponders.com",
     "github_username": "emmapowers",
     "github_repo": "bakelite",
     "default_branch": "master",

--- a/examples/chat/cpptiny/bakelite.h
+++ b/examples/chat/cpptiny/bakelite.h
@@ -1,5 +1,5 @@
 /*
- * The code in this file is Copyright (c) Emma Powers 2021,
+ * The code in this file is Copyright (c) Emma Powers 2021-2025,
  * unless otherwise marked. This software is made available
  * under the terms of the MIT License, which can be found at the
  * bottom of this file.

--- a/examples/chat/ctiny/bakelite.h
+++ b/examples/chat/ctiny/bakelite.h
@@ -1,6 +1,6 @@
 /*
  * Bakelite C Runtime
- * Copyright (c) Emma Powers 2021-2024
+ * Copyright (c) Emma Powers 2021-2025
  *
  * C99 compatible header-only implementation for embedded systems.
  * Licensed under the MIT License (see end of file).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A utility that makes it simple to communicate with your firmware.
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13"
-authors = [{ name = "Emma Powers", email = "emmapowers@gmail.com" }]
+authors = [{ name = "Emma Powers", email = "emma@emmaponders.com" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Natural Language :: English",


### PR DESCRIPTION
## Summary
- Update copyright years to 2025
- Fix email to emma@emmaponders.com
- Applies to: LICENSE.md, pyproject.toml, template headers, bin/update

## Test plan
- [ ] Trivial change, visual review only